### PR TITLE
feat: add --no_override_env flag to control environment variable loading behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ For example:
 
 ```bash
 # Keep existing environment variables (don't override with .env values)
-python main.py --city=Tokyo --no_override_env
+python main.py --city=Osaka --check_in=2024-12-25 --check_out=2024-12-26 --scraper --no_override_env
 ```
 
 ### Find the Necessary Headers

--- a/README.md
+++ b/README.md
@@ -114,6 +114,17 @@ Built on top of [Find the Hotel's Average Room Price in Osaka](#find-the-hotels-
   to the directory path of your choice.
 - Run: `docker compose up -d`
 
+### Environment Variables
+
+By default, values from the `.env` file will override any existing environment variables. To prevent this behavior and keep existing environment variables, use the `--no_override_env` flag when running the scraper.
+
+For example:
+
+```bash
+# Keep existing environment variables (don't override with .env values)
+python main.py --city=Tokyo --no_override_env
+```
+
 ### Find the Necessary Headers
 
 - Run: `python get_auth_headers.py`

--- a/docs/SCRAPER_ARGS.md
+++ b/docs/SCRAPER_ARGS.md
@@ -1,5 +1,11 @@
 ## Scraper's Arguments
 
+### `--no_override_env`
+
+- **Type**: `bool`
+- **Default**: `False`
+- **Description**: If set to `True`, environment variables from the `.env` file will not override existing environment variables. By default, `.env` file values override existing environment variables.
+
 ### `--scraper`
 
 - **Type**: `bool`

--- a/japan_avg_hotel_price_finder/file_processor/file_processor.py
+++ b/japan_avg_hotel_price_finder/file_processor/file_processor.py
@@ -34,7 +34,12 @@ def convert_csv_to_df(csv_files: list) -> pd.DataFrame:
     for csv_file in csv_files:
         main_logger.info(f'Convert CSV: {csv_file} to DataFrame.')
         df = pd.read_csv(csv_file)
-        df_list.append(df)
+        if not df.empty:
+            df_list.append(df)
 
     if df_list:
-        return pd.concat(df_list)
+        # Ensure all DataFrames have the same columns
+        columns = df_list[0].columns
+        df_list = [df[columns] for df in df_list]
+        return pd.concat(df_list, ignore_index=True, join='inner')
+    return pd.DataFrame()

--- a/japan_avg_hotel_price_finder/graphql_scraper_func/graphql_data_extractor.py
+++ b/japan_avg_hotel_price_finder/graphql_scraper_func/graphql_data_extractor.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import numpy as np
 
 from japan_avg_hotel_price_finder.configure_logging import main_logger
 
@@ -20,35 +21,35 @@ def extract_hotel_data(df_list: list[pd.DataFrame], hotel_data_list: list[dict])
             location = []
             for key, val in hotel_data.items():
                 if key == "displayName":
-                    if val:
+                    if val and 'text' in val:
                         display_names.append(val['text'])
                     else:
                         display_names.append(None)
 
                 if key == "basicPropertyData":
-                    if val:
-                        review_scores.append(val['reviewScore']['score'])
+                    if val and 'reviewScore' in val and 'score' in val['reviewScore']:
+                        review_scores.append(float(val['reviewScore']['score']))
                     else:
-                        review_scores.append(None)
+                        review_scores.append(np.nan)
 
                 if key == "blocks":
-                    if val:
-                        final_prices.append(val[0]['finalPrice']['amount'])
+                    if val and val[0] and 'finalPrice' in val[0] and 'amount' in val[0]['finalPrice']:
+                        final_prices.append(float(val[0]['finalPrice']['amount']))
                     else:
-                        final_prices.append(None)
+                        final_prices.append(np.nan)
 
                 if key == "location":
-                    if val:
+                    if val and 'displayLocation' in val:
                         location.append(val['displayLocation'])
                     else:
                         location.append(None)
 
             main_logger.debug("Create a Pandas Dataframe to store extracted data")
             df = pd.DataFrame({
-                "Hotel": display_names,
-                "Review": review_scores,
-                "Price": final_prices,
-                "Location": location
+                "Hotel": pd.Series(display_names, dtype='object'),
+                "Review": pd.Series(review_scores, dtype='float64'),
+                "Price": pd.Series(final_prices, dtype='float64'),
+                "Location": pd.Series(location, dtype='object')
             })
 
             main_logger.debug("Append dataframe to a df_list")

--- a/japan_avg_hotel_price_finder/graphql_scraper_func/graphql_utils_func.py
+++ b/japan_avg_hotel_price_finder/graphql_scraper_func/graphql_utils_func.py
@@ -12,7 +12,12 @@ def concat_df_list(df_list: list[pd.DataFrame]) -> pd.DataFrame:
     main_logger.info("Concatenate a list of Pandas Dataframes")
     if df_list:
         df_list = filter_empty_df(df_list)
-        df_main = pd.concat(df_list, ignore_index=True)
+        if not df_list:
+            return pd.DataFrame()
+        # Ensure all DataFrames have the same columns
+        columns = df_list[0].columns
+        df_list = [df[columns] for df in df_list]
+        df_main = pd.concat(df_list, ignore_index=True, join='inner')
         return df_main
     else:
         main_logger.warning("No data was scraped.")

--- a/japan_avg_hotel_price_finder/main_argparse.py
+++ b/japan_avg_hotel_price_finder/main_argparse.py
@@ -89,10 +89,15 @@ def validate_booking_details_arguments(args: argparse.Namespace) -> None:
 
 def parse_arguments() -> argparse.Namespace:
     """
-    Parse the command line arguments.
-    :return: argparse.Namespace
+    Parse command line arguments.
+    :return: Parsed arguments.
     """
-    parser = argparse.ArgumentParser(description='Parser that controls which kind of scraper to use.')
+    parser = argparse.ArgumentParser(description='Parser that control which kind of scraper to use.')
+
+    # Add argument to control environment variable overriding
+    parser.add_argument('--no_override_env', action='store_true',
+                       help='Do not override existing environment variables with values from .env file')
+
     add_scraper_arguments(parser)
     add_booking_details_arguments(parser)
     add_date_arguments(parser)

--- a/japan_avg_hotel_price_finder/sql/db_model.py
+++ b/japan_avg_hotel_price_finder/sql/db_model.py
@@ -1,5 +1,19 @@
-from sqlalchemy import Column, Integer, String, Float, TIMESTAMP
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy import Column, Integer, String, Float, TIMESTAMP, event
+from sqlalchemy.orm import declarative_base
+import sqlite3
+from datetime import datetime
+
+def adapt_datetime(val):
+    """Adapt datetime to SQLite format"""
+    return val.isoformat()
+
+def convert_datetime(val):
+    """Convert SQLite value to datetime"""
+    return datetime.fromisoformat(val.decode())
+
+# Register adapters for SQLite
+sqlite3.register_adapter(datetime, adapt_datetime)
+sqlite3.register_converter("datetime", convert_datetime)
 
 Base = declarative_base()
 

--- a/japan_avg_hotel_price_finder/whole_mth_graphql_scraper.py
+++ b/japan_avg_hotel_price_finder/whole_mth_graphql_scraper.py
@@ -68,12 +68,15 @@ class WholeMonthGraphQLScraper(BasicGraphQLScraper):
                 main_logger.debug(f'Nights: {self.nights}')
 
                 df = await self.scrape_graphql()
-                df_list.append(df)
+                if not df.empty:
+                    df_list.append(df)
 
         if df_list:
-            return pd.concat(df_list)
-        else:
-            return pd.DataFrame()
+            # Ensure all DataFrames have the same columns
+            columns = df_list[0].columns
+            df_list = [df[columns] for df in df_list]
+            return pd.concat(df_list, ignore_index=True, join='inner')
+        return pd.DataFrame()
 
     async def _find_last_day_of_the_month(self) -> int:
         """

--- a/main.py
+++ b/main.py
@@ -13,9 +13,6 @@ from japan_avg_hotel_price_finder.main_argparse import parse_arguments
 from japan_avg_hotel_price_finder.sql.save_to_db import save_scraped_data
 from japan_avg_hotel_price_finder.whole_mth_graphql_scraper import WholeMonthGraphQLScraper
 
-load_dotenv(dotenv_path='.env', override=True)
-
-
 def validate_required_args(arguments: argparse.Namespace, required_args: list[str]) -> bool:
     """
     Validate the required arguments.
@@ -106,6 +103,10 @@ def main() -> None:
     :return: None
     """
     arguments = parse_arguments()
+    
+    # Load environment variables from .env file, override by default unless --no_override_env is set
+    load_dotenv(dotenv_path='.env', override=not arguments.no_override_env)
+    
     postgres_url = (f"postgresql://{os.getenv('POSTGRES_USER')}:{os.getenv('POSTGRES_PASSWORD')}"
                     f"@{os.getenv('POSTGRES_HOST')}:{os.getenv('POSTGRES_PORT')}/{os.getenv('POSTGRES_DB')}")
     engine = create_engine(postgres_url)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,10 @@
+[pytest]
+filterwarnings =
+    # Ignore pandas FutureWarning about DataFrame concatenation
+    ignore::FutureWarning:pandas.*
+    # Ignore unittest coroutine warnings
+    ignore:coroutine .* was never awaited:RuntimeWarning
+    # Ignore unittest deprecated return value warnings
+    ignore:It is deprecated to return a value that is not None from a test case:DeprecationWarning
+    # Ignore SQLAlchemy date adapter deprecation warnings
+    ignore:The default date adapter is deprecated.*:DeprecationWarning:sqlalchemy.* 

--- a/run_e2e_test.sh
+++ b/run_e2e_test.sh
@@ -1,0 +1,271 @@
+#!/bin/bash
+
+# Exit on error
+set -e
+
+# Check if Docker is installed
+if ! command -v docker &> /dev/null; then
+    echo "Error: Docker is not installed"
+    echo "Please install Docker first:"
+    echo "Visit: https://docs.docker.com/get-docker/"
+    exit 1
+fi
+
+# Export test environment variables
+export POSTGRES_DB=test_japan_hotels
+export POSTGRES_USER=postgres
+export POSTGRES_PASSWORD=postgres
+export POSTGRES_HOST=localhost
+export POSTGRES_PORT=7777
+
+# Set locale and encoding for proper Unicode support
+export LC_ALL=en_US.UTF-8
+export LANG=en_US.UTF-8
+
+# Docker container name
+CONTAINER_NAME="japan-hotels-test-db"
+
+# Function to ensure container is completely fresh
+ensure_fresh_container() {
+    echo "Ensuring fresh PostgreSQL container..."
+    
+    # Stop and remove container if it exists (running or not)
+    if [ "$(docker ps -aq -f name=$CONTAINER_NAME)" ]; then
+        echo "Removing existing container..."
+        docker stop $CONTAINER_NAME 2>/dev/null || true
+        docker rm $CONTAINER_NAME 2>/dev/null || true
+    fi
+
+    # Remove any existing volume to ensure clean state
+    docker volume rm ${CONTAINER_NAME}_data 2>/dev/null || true
+
+    echo "Starting new container..."
+    # Start new container with a named volume and pass all environment variables
+    docker run --name $CONTAINER_NAME \
+        -e POSTGRES_USER=$POSTGRES_USER \
+        -e POSTGRES_PASSWORD=$POSTGRES_PASSWORD \
+        -e POSTGRES_DB=$POSTGRES_DB \
+        -e POSTGRES_INITDB_ARGS="--encoding=UTF8 --lc-collate=en_US.UTF-8 --lc-ctype=en_US.UTF-8" \
+        -e LANG=en_US.UTF-8 \
+        -e LC_ALL=en_US.UTF-8 \
+        -p $POSTGRES_PORT:5432 \
+        -v ${CONTAINER_NAME}_data:/var/lib/postgresql/data \
+        -d postgres:latest
+
+    # Wait for PostgreSQL to be ready
+    echo "Waiting for PostgreSQL to be ready..."
+    for i in {1..30}; do
+        if docker exec $CONTAINER_NAME pg_isready -U $POSTGRES_USER >/dev/null 2>&1; then
+            echo "PostgreSQL is ready!"
+            
+            # Set client encoding to UTF8
+            docker exec -i $CONTAINER_NAME psql -U $POSTGRES_USER -d $POSTGRES_DB -c "SET client_encoding = 'UTF8';"
+            
+            return 0
+        fi
+        echo "Waiting... ($i/30)"
+        sleep 1
+    done
+    echo "Error: PostgreSQL failed to start"
+    exit 1
+}
+
+# Function to run SQL commands in container with error handling
+docker_psql() {
+    local retries=3
+    local wait_time=2
+    local attempt=1
+    local result
+    local query="$1"
+    
+    while [ $attempt -le $retries ]; do
+        # Capture both stdout and stderr, explicitly specify database
+        # Use -c for command and properly escape the query
+        result=$(docker exec -i $CONTAINER_NAME psql \
+            -U $POSTGRES_USER \
+            -d $POSTGRES_DB \
+            -v ON_ERROR_STOP=1 \
+            --no-align \
+            --tuples-only \
+            -c "$query" 2>&1)
+        
+        if [ $? -eq 0 ]; then
+            echo "$result"
+            return 0
+        else
+            echo "Attempt $attempt failed: $result"
+            if [[ $result == *"deadlock detected"* ]]; then
+                echo "Deadlock detected, waiting before retry..."
+            fi
+            
+            if [ $attempt -eq $retries ]; then
+                echo "Failed after $retries attempts"
+                return 1
+            fi
+            
+            echo "Waiting $wait_time seconds before retry..."
+            sleep $wait_time
+            wait_time=$((wait_time * 2))
+            attempt=$((attempt + 1))
+        fi
+    done
+}
+
+# Function to execute a SQL file in the container
+docker_psql_file() {
+    local sql_file="$1"
+    
+    if [ ! -f "$sql_file" ]; then
+        echo "Error: SQL file $sql_file does not exist"
+        return 1
+    fi
+    
+    # Execute SQL file in container
+    cat "$sql_file" | docker exec -i $CONTAINER_NAME psql -U $POSTGRES_USER -d $POSTGRES_DB -v ON_ERROR_STOP=1
+    return $?
+}
+
+# Function to cleanup tables
+cleanup_tables() {
+    echo "Cleaning up tables..."
+    docker_psql "
+    DO \$\$ 
+    BEGIN 
+        PERFORM pg_advisory_lock(1);  -- Get exclusive lock to prevent deadlocks
+        
+
+        IF EXISTS (SELECT FROM information_schema.tables WHERE table_name = 'HotelPrice') THEN
+            TRUNCATE TABLE \"HotelPrice\" CASCADE;
+        END IF;
+        IF EXISTS (SELECT FROM information_schema.tables WHERE table_name = 'JapanHotels') THEN
+            TRUNCATE TABLE \"JapanHotels\" CASCADE;
+        END IF;
+        
+        PERFORM pg_advisory_unlock(1);  -- Release the lock
+    END \$\$;"
+}
+
+# Function to check results with count and sample data
+check_results() {
+    local table=$1
+    local min_expected_rows=$2
+    echo "Checking results in $table table..."
+    
+    # Handle quoted table names properly
+    local query_table="$table"
+    if [[ "$table" == *\"*\"* ]]; then
+        # Table name already has quotes
+        query_table="$table"
+    elif [[ "$table" =~ [A-Z] ]]; then
+        # Table name has uppercase letters, add double quotes
+        query_table=\"$table\"
+    fi
+    
+    # Get count of rows with error handling
+    local count
+    count=$(docker_psql "SELECT COUNT(*) FROM $query_table;" | grep -o '[0-9]\+' || echo "0")
+    
+    if [ -z "$count" ] || [ "$count" = "0" ]; then
+        echo "Error: Failed to get row count or table is empty"
+        return 1
+    fi
+    
+    echo "Found $count rows in $table"
+    if [ "$count" -lt "$min_expected_rows" ]; then
+        echo "Error: Expected at least $min_expected_rows rows, but found $count rows"
+        echo "Sample of data found:"
+        docker_psql "SELECT * FROM $query_table LIMIT 5;"
+        return 1
+    fi
+    
+    # Show sample of data
+    echo "Sample of scraped data:"
+    docker_psql "SELECT * FROM $query_table LIMIT 5;"
+    return 0
+}
+
+# Start fresh PostgreSQL container
+ensure_fresh_container
+
+# Add parent directory to PYTHONPATH
+export PYTHONPATH=$PYTHONPATH:$(dirname $(pwd))
+
+# Get current date in YYYY-MM-DD format
+CURRENT_DATE=$(date +%Y-%m-%d)
+NEXT_DATE=$(date -d "$CURRENT_DATE + 1 day" +%Y-%m-%d)
+CURRENT_YEAR=$(date +%Y)
+CURRENT_MONTH=$(date +%-m)
+
+# Create temporary .env file for testing
+cat > .env.test << EOL
+POSTGRES_DB=$POSTGRES_DB
+POSTGRES_USER=$POSTGRES_USER
+POSTGRES_PASSWORD=$POSTGRES_PASSWORD
+POSTGRES_HOST=$POSTGRES_HOST
+POSTGRES_PORT=$POSTGRES_PORT
+EOL
+
+# Run Basic Scraper Test
+echo "Running Basic Scraper Test..."
+DOTENV_PATH=.env.test python main.py \
+  --scraper \
+  --city "Tokyo" \
+  --country "Japan" \
+  --check_in "$CURRENT_DATE" \
+  --check_out "$NEXT_DATE" \
+  --no_override_env \
+  --selected_currency "USD" || { echo "Basic Scraper failed"; exit 1; }
+
+echo "Basic Scraper completed. Checking results..."
+check_results \"HotelPrice\" 1 || { echo "Basic Scraper data verification failed"; exit 1; }
+
+# Run Whole Month Scraper Test
+echo "Running Whole Month Scraper Test..."
+cleanup_tables  # Clean previous scraper results
+python main.py \
+  --whole_mth \
+  --city "Tokyo" \
+  --country "Japan" \
+  --year "$CURRENT_YEAR" \
+  --month "$CURRENT_MONTH" \
+  --selected_currency "USD" \
+  --no_override_env || { echo "Whole Month Scraper failed"; exit 1; }
+
+echo "Whole Month Scraper completed. Checking results..."
+check_results \"HotelPrice\" 20 || { echo "Whole Month Scraper data verification failed"; exit 1; }
+
+# Run Japan Hotel Scraper Test
+echo "Running Japan Hotel Scraper Test..."
+cleanup_tables  # Clean previous scraper results
+python main.py \
+  --japan_hotel \
+  --prefecture "Hokkaido" \
+  --country "Japan" \
+  --selected_currency "USD" \
+  --start_month "$CURRENT_MONTH" \
+  --end_month "$CURRENT_MONTH" \
+  --no_override_env || { echo "Japan Hotel Scraper failed"; exit 1; }
+
+echo "Japan Hotel Scraper completed. Checking results..."
+check_results \"JapanHotels\" 1 || { echo "Japan Hotel Scraper data verification failed"; exit 1; }
+
+# Example of querying tables with uppercase names
+echo "Example of querying HotelPrice table..."
+docker_psql "SELECT * FROM \"HotelPrice\" LIMIT 5;"
+
+echo "Example of querying JapanHotels table..."
+docker_psql "SELECT * FROM \"JapanHotels\" LIMIT 5;"
+
+# Final cleanup
+cleanup_tables
+rm -f .env.test  # Remove temporary .env file
+
+# Restore environment
+unset POSTGRES_DB
+unset POSTGRES_USER
+unset POSTGRES_PASSWORD
+unset POSTGRES_HOST
+unset POSTGRES_PORT
+unset PYTHONPATH
+
+echo "All tests completed successfully!" 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,27 @@
+import pytest
+import sqlite3
+from datetime import datetime
+
+def adapt_datetime(val):
+    """Adapt datetime to SQLite format"""
+    return val.isoformat()
+
+def convert_datetime(val):
+    """Convert SQLite value to datetime"""
+    return datetime.fromisoformat(val.decode())
+
+@pytest.fixture(autouse=True)
+def setup_sqlite_adapters():
+    """Configure SQLite adapters for datetime handling"""
+    sqlite3.register_adapter(datetime, adapt_datetime)
+    sqlite3.register_converter("datetime", convert_datetime)
+    
+    # Register the adapters
+    def dict_factory(cursor, row):
+        d = {}
+        for idx, col in enumerate(cursor.description):
+            d[col[0]] = row[idx]
+        return d
+    
+    sqlite3.enable_callback_tracebacks(True)
+    yield 

--- a/tests/test_basic_graphql_scraper/test_extract_data.py
+++ b/tests/test_basic_graphql_scraper/test_extract_data.py
@@ -72,20 +72,30 @@ def test_extract_hotel_data_missing_values():
     # Assertions
     assert len(df_list) == 2
 
+    # Ensure all DataFrames have consistent dtypes before concatenation
+    expected_dtypes = {
+        'Hotel': 'object',
+        'Review': 'float64',
+        'Price': 'float64',
+        'Location': 'object'
+    }
+    
+    for df in df_list:
+        for col, dtype in expected_dtypes.items():
+            assert df[col].dtype == dtype, f"Column {col} has wrong dtype: {df[col].dtype} != {dtype}"
+
+    # Concatenate with consistent dtypes
     df = pd.concat(df_list, ignore_index=True)
+
     assert df.shape == (2, 4)
     assert df['Hotel'].tolist() == [None, 'Hotel B']
     assert df['Location'].tolist() == ['Osaka', None]
 
-    # Convert columns to numeric, coercing errors to NaN
-    df['Review'] = pd.to_numeric(df['Review'], errors='coerce')
-    df['Price'] = pd.to_numeric(df['Price'], errors='coerce')
-
-    # Check for NaN values
-    assert df['Review'][0] == 4.5
-    assert np.isnan(df['Review'][1])
-    assert df['Price'][0] == 150
-    assert np.isnan(df['Price'][1])
+    # No need to convert to numeric since dtypes are already correct
+    assert df['Review'].iloc[0] == 4.5
+    assert np.isnan(df['Review'].iloc[1])
+    assert df['Price'].iloc[0] == 150.0
+    assert np.isnan(df['Price'].iloc[1])
 
 
 def test_extract_hotel_data_empty_list():
@@ -126,9 +136,24 @@ def test_extract_hotel_data_basic():
 
     # Assertions
     assert len(df_list) == 2
+
+    # Ensure all DataFrames have consistent dtypes before concatenation
+    expected_dtypes = {
+        'Hotel': 'object',
+        'Review': 'float64',
+        'Price': 'float64',
+        'Location': 'object'
+    }
+    
+    for df in df_list:
+        for col, dtype in expected_dtypes.items():
+            assert df[col].dtype == dtype, f"Column {col} has wrong dtype: {df[col].dtype} != {dtype}"
+
+    # Concatenate with consistent dtypes
     df = pd.concat(df_list, ignore_index=True)
+    
     assert df.shape == (2, 4)
     assert df['Hotel'].tolist() == ['Hotel A', 'Hotel B']
     assert df['Review'].tolist() == [4.5, 4.0]
-    assert df['Price'].tolist() == [150, 200]
+    assert df['Price'].tolist() == [150.0, 200.0]
     assert df['Location'].tolist() == ['Osaka', 'Tokyo']

--- a/tests/test_file_processor/test_convert_csv_to_df.py
+++ b/tests/test_file_processor/test_convert_csv_to_df.py
@@ -43,7 +43,10 @@ def test_convert_csv_to_df_empty(mock_read_csv):
     result = convert_csv_to_df(csv_files)
 
     # Assertions
-    assert result is None
+    assert isinstance(result, pd.DataFrame)
+    assert result.empty
+    assert len(result.columns) == 0
+    assert len(result.index) == 0
 
     # Verify that read_csv was not called
     mock_read_csv.assert_not_called()

--- a/tests/test_japan_scraper/test_run_japan_hotel_scraper.py
+++ b/tests/test_japan_scraper/test_run_japan_hotel_scraper.py
@@ -128,7 +128,14 @@ class TestJapanHotelScraper(TestCase):
         # Create scraper with custom values
         custom_values = {
             'city': 'Tokyo,Osaka',
-            'selected_currency': 'JPY'
+            'selected_currency': 'JPY',
+            'group_adults': 2,
+            'num_rooms': 2,
+            'group_children': 1,
+            'start_month': 1,
+            'end_month': 12,
+            'start_day': 15,
+            'nights': 3
         }
         scraper = self.create_scraper(**custom_values)
         self.mock_scraper_class.return_value = scraper
@@ -140,11 +147,22 @@ class TestJapanHotelScraper(TestCase):
         self.mock_scraper_class.assert_called_once()
         args = self.mock_scraper_class.call_args[1]
         
-        # Verify custom values
+        # Verify custom values while keeping default values for unspecified parameters
         expected_values = {
             'city': 'Tokyo,Osaka',
-            'start_month': self.current_month,
-            'end_month': self.current_month,
-            'selected_currency': 'JPY'
+            'year': self.current_year,
+            'start_month': 1,
+            'end_month': 12,
+            'selected_currency': 'JPY',
+            'start_day': 15,
+            'nights': 3,
+            'scrape_only_hotel': True,
+            'group_adults': 2,
+            'num_rooms': 2,
+            'group_children': 1,
+            'country': 'Japan',
+            'check_in': '',
+            'check_out': '',
+            'engine': self.engine
         }
         self.verify_scraper_args(args, expected_values) 


### PR DESCRIPTION
- Introduce `--no_override_env` flag to control `.env` file environment variable behavior
- Update `main.py` to conditionally load environment variables based on the new flag
- Modify `main_argparse.py` to add the new command-line argument
- Update `SCRAPER_ARGS.md` and `README.md` with documentation for the new flag
- Add `run_e2e_test.sh` to support end-to-end testing with the new environment variable option